### PR TITLE
Use newunit() from utils instead of F2008

### DIFF
--- a/tests/pseudopotential/vloc_nonrel_dft.f90
+++ b/tests/pseudopotential/vloc_nonrel_dft.f90
@@ -3,7 +3,7 @@ use dftatom, only: dp, mesh_exp, mesh_exp_deriv, thomas_fermi_potential, E_nl
 use dft_data, only: dft_data_t
 use dft, only: KS_step
 use mixings, only: mixing_anderson
-use utils, only: assert
+use utils, only: assert, newunit
 implicit none
 
 ! Mesh parameters:
@@ -104,7 +104,7 @@ print *, "The first 10 values of the Hartree potential (V_h):"
 print *, V_h(:10)
 
 ! Save the radial grid, density, V_h
-open(newunit=u, file="density.txt", status="replace")
+open(newunit(u), file="density.txt", status="replace")
 write(u, "((es23.16, ' ', es23.16, ' ', es23.16))") (R(i), density(i), V_h(i), &
         i=1, size(R))
 close(u)

--- a/tests/pseudopotential/vloc_nonrel_dft_hyp.f90
+++ b/tests/pseudopotential/vloc_nonrel_dft_hyp.f90
@@ -5,7 +5,7 @@ use dftatom, only: dp, thomas_fermi_potential, E_nl
 use dft_data, only: dft_data_t
 use dft, only: KS_step
 use mixings, only: mixing_anderson
-use utils, only: assert, stop_error
+use utils, only: assert, stop_error, newunit
 implicit none
 
 ! Mesh parameters:
@@ -103,7 +103,7 @@ print *, "The first 10 values of the radial charge density:"
 print *, density(:10)
 
 ! Save the radial grid and density
-!open(newunit=u, file="density.txt", status="replace")
+!open(newunit(u), file="density.txt", status="replace")
 !write(u, "((es23.16, ' ', es23.16))") (R(i), density(i), i=1, size(R))
 !close(u)
 


### PR DESCRIPTION
The main program is strictly F95 compliant, as well as tests that are compiled
using the Makefile.manual approach. Some other tests use features from F2003
and F2008. The newunit() is easy to fix to work with F95, so we fix it with
this patch.
