### PR TITLE
Travis-CI: drop support for Python 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.5
   - 2.6
   - 2.7
 before_install:


### PR DESCRIPTION
As announced at [1]: "Python 2.5 has been removed due to very low overall usage
and breaking changes in pip and virtualenv."

[1] http://about.travis-ci.org/blog/2013-11-18-upcoming-build-environment-updates/
