### PR TITLE
Travis: switch Python 3.7 and 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - 2.7
+  - 3.7
 env:
   - TEST_MANUAL="yes"
   - BUILD_TYPE="Debug"
@@ -10,7 +10,7 @@ env:
   - BUILD_TYPE="Release" WITH_PYTHON="yes"
 matrix:
   include:
-    - python: 3.7
+    - python: 2.7
       env:
         - BUILD_TYPE="Debug" WITH_PYTHON="yes"
 before_install:


### PR DESCRIPTION
Now most tests are done with Python 3.7, which is the most supported version.
We only run one tests with Python 2.7 to ensure it still works.