### PR TITLE
Modernize CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_SOURCE_DIR}/cmake/UserOverride.cmake)
 
@@ -61,6 +61,7 @@ message("\n")
 message("Configuration results")
 message("---------------------")
 message("Fortran compiler: ${CMAKE_Fortran_COMPILER}")
+message("CMAKE_Fortran_COMPILER_ID: ${CMAKE_Fortran_COMPILER_ID}")
 message("Build type: ${CMAKE_BUILD_TYPE}")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     message("Fortran compiler flags: ${CMAKE_Fortran_FLAGS_DEBUG}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ if(WITH_C_INTERFACE)
     set(SRC ${SRC} c_dftatom.f90)
 endif()
 
-add_library(dftatom SHARED ${SRC})
+add_library(dftatom ${SRC})
 target_include_directories(dftatom PUBLIC
     $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
     $<INSTALL_INTERFACE:include/dftatom>

--- a/tests/pseudopotential/CMakeLists.txt
+++ b/tests/pseudopotential/CMakeLists.txt
@@ -3,7 +3,9 @@ include_directories(${PROJECT_BINARY_DIR}/src)
 project(pseudopotential)
 
 # The erf() function is part of the F2008 standard
-add_definitions("-std=f2008")
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    add_definitions("-std=f2008")
+endif()
 
 add_executable(vloc_nonrel vloc_nonrel.f90)
 target_link_libraries(vloc_nonrel dftatom)


### PR DESCRIPTION
* Update minimum version
* Print CMAKE_Fortran_COMPILER_ID
* Do not hardcore shared library requirement (can be selected at the command line)
* Only set `-std=f2008` for GFortran