### PR TITLE
CI: test dftatom with LFortran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,68 @@ jobs:
           ./tests/atom_U/F_atom_U
           ctest -E "conv_lda|conv_rlda|fd|rmin_conv|N_conv"
 
+
+  build_lfortran:
+    name: LFortran build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Uninstall gfortran
+        run: |
+          set -ex
+          sudo apt-get purge gfortran
+
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: lf
+          create-args: >-
+            lfortran=0.27.0
+
+      - name: Print installed packages information
+        shell: bash -l {0}
+        run: |
+            set -ex
+            ! which lfortran
+            micromamba env list
+            micromamba activate lf
+            micromamba list
+            which lfortran
+
+      - name: Build dftatom manual
+        shell: bash -l {0}
+        run: |
+          set -ex
+          make -f Makefile.manual F90=lfortran F90FLAGS="-I../../src"
+          ./tests/atom_U/F_atom_U
+          #make -f Makefile.manual test
+          git clean -dfx
+          make -f Makefile.manual F90="lfortran --skip-pass=inline_function_calls,fma --fast" F90FLAGS="-I../../src"
+          ./tests/atom_U/F_atom_U
+          #make -f Makefile.manual test
+          git clean -dfx
+
+      - name: Build dftatom cmake
+        shell: bash -l {0}
+        run: |
+          set -ex
+          cmake -DCMAKE_BUILD_TYPE=Debug .
+          make
+          ctest -E "conv_lda|conv_rlda"
+          git clean -dfx
+          cmake -DCMAKE_BUILD_TYPE=Release .
+          make
+          ctest -E "conv_lda|conv_rlda"
+
+
   build_python:
     name: Python build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install packages
         run: |
           set -ex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ enable_language(Fortran)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod_files)
 
+# Until CMake supports LFortran natively, we recognize it by hand and set the
+# native CMAKE_Fortran_COMPILER_ID variable.
+string(REGEX MATCH "lfortran" fortran_compiler_suffix ${CMAKE_Fortran_COMPILER})
+if(fortran_compiler_suffix STREQUAL lfortran)
+    set(CMAKE_Fortran_COMPILER_ID "LFortran")
+    set(CMAKE_Fortran_FLAGS_RELEASE "--fast --skip-pass=inline_function_calls,fma")
+endif()
+
 # Make sure that CMAKE_BUILD_TYPE is either Debug or Release:
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release

--- a/tests/well/CMakeLists.txt
+++ b/tests/well/CMakeLists.txt
@@ -5,6 +5,11 @@ project(well)
 set(SRC
     special.f90 optimize.f90
     )
+
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "LFortran")
+    add_definitions("--implicit-typing")
+endif()
+
 add_library(well ${SRC})
 add_dependencies(well dftatom)
 


### PR DESCRIPTION
LFortran now compiles dftatom without any workarounds. We add support into CMake, and enable testing at the CI.