### PR TITLE
Coulomb benchmark

### DIFF
--- a/src/states.f90
+++ b/src/states.f90
@@ -26,6 +26,7 @@ real(dp), pointer :: fo(:) ! occupancy of the (n, l) state
 ! Note: sum(fo) == Z
 
 integer :: n
+integer :: i, l
 
 select case (Z)
 
@@ -667,11 +668,18 @@ select case (Z)
         fo = (/ 2, 2, 6, 2, 6, 10, 2, 6, 10, 14, 2, 6, 10, 2, 2, 6, 1, 2 /)
 
     case (92)
-        n = 18
+        n = 27
         allocate(no(n), lo(n), fo(n))
-        no = (/ 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 7 /)
-        lo = (/ 0, 0, 1, 0, 1, 2, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 0 /)
-        fo = (/ 2, 2, 6, 2, 6, 10, 2, 6, 10, 14, 2, 6, 10, 3, 2, 6, 1, 2 /)
+        i = 1
+        outer: do n = 1, 7
+            do l = 0, n-1
+                no(i) = n
+                lo(i) = l
+                fo(i) = 2
+                if (n == 7 .and. l == 5) exit outer
+                i = i + 1
+            end do
+        end do outer
 
     case default
         print *, "Z =", Z


### PR DESCRIPTION
```
$ time ./uranium_rel
 Hydrogen like relativistic energies for Z=92 (U)
 Mesh parameters (r_min, r_max, a, N):
  1.00E-08     50.00  6.20E+07      4500

  n  l  k              E        E_exact     Error

  1  0  0   -4861.197905   -4861.197905  1.39E-07
  2  0  0   -1257.395852   -1257.395852  1.62E-08
  2  1  0   -1089.611416   -1089.611416  2.96E-12
  2  1  1   -1257.395852   -1257.395852  5.09E-08
  3  0  0    -539.093329    -539.093329  1.46E-07
  3  1  0    -489.037085    -489.037085  4.64E-08
  3  1  1    -539.093329    -539.093329  1.44E-07
  3  2  0    -476.261594    -476.261594  1.52E-10
  3  2  1    -489.037085    -489.037085  4.61E-08
  4  0  0    -295.257839    -295.257839  2.65E-07
  4  1  0    -274.407758    -274.407757  1.55E-07
  4  1  1    -295.257839    -295.257839  2.66E-07
  4  2  0    -268.965877    -268.965877  3.92E-08
  4  2  1    -274.407758    -274.407757  1.55E-07
  4  3  0    -266.389446    -266.389447  4.30E-07
  4  3  1    -268.965877    -268.965877  3.91E-08
  5  0  0    -185.485189    -185.485189  4.60E-07
  5  1  0    -174.944613    -174.944613  1.97E-07
  5  1  1    -185.485189    -185.485189  4.60E-07
  5  2  0    -172.155252    -172.155252  1.47E-07
  5  2  1    -174.944613    -174.944613  1.93E-07
  5  3  0    -170.828937    -170.828937  3.30E-08
  5  3  1    -172.155252    -172.155252  1.47E-07
  5  4  0    -170.049934    -170.049934  8.07E-10
  5  4  1    -170.828937    -170.828937  3.33E-08
  6  0  0    -127.093638    -127.093637  6.69E-07
  6  1  0    -121.057538    -121.057538  5.35E-07
  6  1  1    -127.093638    -127.093637  6.74E-07
  6  2  0    -119.445272    -119.445272  3.14E-07
  6  2  1    -121.057538    -121.057538  5.36E-07
  6  3  0    -118.676410    -118.676410  1.29E-07
  6  3  1    -119.445272    -119.445272  3.12E-07
  6  4  0    -118.224145    -118.224145  1.83E-08
  6  4  1    -118.676410    -118.676410  1.25E-07
  6  5  0    -117.925826    -117.925826  2.12E-09
  6  5  1    -118.224144    -118.224145  1.80E-07
  7  0  0     -92.440787     -92.440787  8.82E-07
  7  1  0     -88.671750     -88.671749  7.94E-07
  7  1  1     -92.440787     -92.440787  8.65E-07
  7  2  0     -87.658288     -87.658287  5.57E-07
  7  2  1     -88.671750     -88.671749  7.98E-07
  7  3  0     -87.173967     -87.173967  3.12E-07
  7  3  1     -87.658288     -87.658287  5.52E-07
  7  4  0     -86.888766     -86.888766  1.25E-07
  7  4  1     -87.173967     -87.173967  3.13E-07
  7  5  0     -86.700520     -86.700520  2.59E-08
  7  5  1     -86.888766     -86.888766  1.25E-07
./uranium_rel  0.06s user 0.00s system 89% cpu 0.067 total
```