### PR TITLE
Implement `make quicktest` for quick testing

### DIFF
--- a/Makefile.manual
+++ b/Makefile.manual
@@ -2,7 +2,7 @@
 
 # GFortran
 F90 = gfortran
-F90FLAGS = -Wall -std=f95 -Wextra -Wimplicit-interface -fPIC
+F90FLAGS = -Wall -std=f2003 -Wextra -Wimplicit-interface -fPIC
 # Debug flags:
 F90FLAGS += -g -fbounds-check
 # Release flags:
@@ -27,6 +27,11 @@ all:
 
 test:
 	cd tests; make -f Makefile.manual test
+	@echo
+	@echo "All tests passed."
+
+quicktest:
+	cd tests; make -f Makefile.manual quicktest
 	@echo
 	@echo "All tests passed."
 

--- a/tests/Makefile.manual
+++ b/tests/Makefile.manual
@@ -13,6 +13,11 @@ test:
 	cd rlda; make -f Makefile.manual test
 	cd atom_U; make -f Makefile.manual test
 
+quicktest:
+	cd lda; make -f Makefile.manual quicktest
+	cd rlda; make -f Makefile.manual quicktest
+	cd atom_U; make -f Makefile.manual test
+
 clean:
 	cd lda; make -f Makefile.manual clean
 	cd rlda; make -f Makefile.manual clean

--- a/tests/Makefile.manual.mk
+++ b/tests/Makefile.manual.mk
@@ -8,6 +8,9 @@ $(PROG): $(OBJS)
 test:
 	./$(PROG)
 
+quicktest:
+	./$(PROG) quicktest
+
 clean:
 	rm -f $(PROG) $(OBJS) *.mod
 

--- a/tests/lda/conv_lda.f90
+++ b/tests/lda/conv_lda.f90
@@ -29,12 +29,17 @@ real(dp), allocatable :: orbitals(:, :)
 real(dp) :: eps
 real(dp), allocatable :: R(:), Rp(:), V_tot(:), density(:)
 integer :: p
+logical :: quicktest
+
+quicktest = (command_argument_count() >= 1)
 
 do p = 3, 8
+    if (quicktest .and. p /= 8) cycle
     eps = 10.0_dp**(-p)
     eps = eps * 1.2_dp ! Allow numerical differences across compilers/platforms
     print *, "Test eps:", eps
     do Z = 92, 1, -1
+        if (quicktest .and. modulo(Z, 23) /= 0) cycle
         n_orb = get_atom_orb(Z)
         NN = get_N(Z, p)
         allocate(ks_energies(n_orb), no(n_orb), &

--- a/tests/rlda/conv_rlda.f90
+++ b/tests/rlda/conv_rlda.f90
@@ -31,12 +31,17 @@ real(dp), allocatable :: orbitals(:, :)
 real(dp), allocatable :: R(:), Rp(:), V_tot(:), density(:)
 real(dp) :: eps
 integer :: p
+logical :: quicktest
+
+quicktest = (command_argument_count() >= 1)
 
 do p = 3, 8
+    if (quicktest .and. p /= 8) cycle
     eps = 10.0_dp**(-p)
     eps = eps * 1.2_dp ! Allow numerical differences across compilers/platforms
     print *, "Test eps:", eps
     do Z = 92, 1, -1
+        if (quicktest .and. modulo(Z, 23) /= 0) cycle
         call get_LDA_energies(Z, ks_energies_exact, E_tot_exact)
         n_orb = size(ks_energies_exact)
         NN = get_N(Z, p)


### PR DESCRIPTION
This allows to use the Makefile system for quick testing also, besides the exhaustive testing.