### PR TITLE
fix python3 interpreter name for systems having both python and python3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,6 @@ jobs:
           set -ex
           sudo apt-get update
           sudo apt-get install -y python3-numpy cython3 python3-pytest
-          sudo ln -s /usr/bin/cython3 /usr/bin/cython
-          sudo ln -s /usr/bin/pytest-3 /usr/bin/pytest
 
       - name: Build dftatom cmake python
         run: |

--- a/cmake/FindNumPy.cmake
+++ b/cmake/FindNumPy.cmake
@@ -1,5 +1,7 @@
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 execute_process(
-	COMMAND python -c "import numpy; print(numpy.get_include())"
+	COMMAND ${Python3_EXECUTABLE} -c "import numpy; print(numpy.get_include())"
 	OUTPUT_VARIABLE PYTHON_SYS_PATH
 	)
 string(STRIP ${PYTHON_SYS_PATH} PYTHON_SYS_PATH)

--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -1,5 +1,7 @@
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 execute_process(
-	COMMAND python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())"
+	COMMAND ${Python3_EXECUTABLE} -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())"
 	OUTPUT_VARIABLE PYTHON_SYS_PATH
 	)
 string(STRIP ${PYTHON_SYS_PATH} PYTHON_SYS_PATH)
@@ -10,13 +12,13 @@ FIND_PATH(PYTHON_INCLUDE_PATH Python.h
     )
 
 execute_process(
-	COMMAND python -c "from distutils.sysconfig import get_config_var; print(get_config_var('LIBDIR'))"
+	COMMAND ${Python3_EXECUTABLE} -c "from distutils.sysconfig import get_config_var; print(get_config_var('LIBDIR'))"
 	OUTPUT_VARIABLE PYTHON_LIB_PATH
 	)
 string(STRIP ${PYTHON_LIB_PATH} PYTHON_LIB_PATH)
 
 execute_process(
-	COMMAND python -c "import sys; print('%s.%s' % sys.version_info[:2])"
+	COMMAND ${Python3_EXECUTABLE} -c "import sys; print('%s.%s' % sys.version_info[:2])"
     OUTPUT_VARIABLE PYTHON_VERSION
 	)
 string(STRIP ${PYTHON_VERSION} PYTHON_VERSION)
@@ -29,7 +31,7 @@ FIND_LIBRARY(PYTHON_LIBRARY NAMES python${PYTHON_VERSION}
     )
 
 execute_process(
-	COMMAND python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
+	COMMAND ${Python3_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
 	OUTPUT_VARIABLE PYTHON_INSTALL_PATH_tmp
 	)
 string(STRIP ${PYTHON_INSTALL_PATH_tmp} PYTHON_INSTALL_PATH_tmp)


### PR DESCRIPTION
This PR assumes we do not need python2 support anymore (is it the case?). On my system 'python' is python2, so this PR fixes the build system to use the correct 'python3' executable name.